### PR TITLE
Add package.json#repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "keywords": [],
   "author": "Brent Jackson",
   "license": "MIT",
+  "repository": "jxnblk/sidepane",
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",


### PR DESCRIPTION
Discovered this repo via mdx-go. I typed in https://npm.im/sidepane and didn't see a link to GitHub (see screenshot below), so add the `repository` field to `package.json` should link to the source. Thank you! 🙏 

![image](https://user-images.githubusercontent.com/2344137/49616996-9dd91f00-f967-11e8-835d-2ae56fdfaf64.png)
